### PR TITLE
Feature: tight time selection to a datetime period boudaries

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -419,16 +419,16 @@ var Datetime = React.createClass({
 		});
 
 		if (!props.isValidDate && (props.boundaryStart || props.boundaryEnd)) {
-			props.isValidDate = function isValidDate(currentDate, selectedDate) {
+			props.isValidDate = function isValidDate(currentDate) {
 				if (props.boundaryStart || props.boundaryEnd) {
 					return currentDate.isSameOrAfter(props.boundaryStart, 'day') 
 						&& currentDate.isSameOrBefore(props.boundaryEnd, 'day');
-				} else if (boundaryStart) {
+				} else if (props.boundaryStart) {
 					return currentDate.isSameOrAfter(props.boundaryStart, 'day');
 				} else {
 					return currentDate.isSameOrBefore(props.boundaryEnd, 'day');
 				}
-			}
+			};
 		}
 
 		return props;

--- a/DateTime.js
+++ b/DateTime.js
@@ -418,19 +418,6 @@ var Datetime = React.createClass({
 			props[ name ] = me[ name ];
 		});
 
-		if (!props.isValidDate && (props.boundaryStart || props.boundaryEnd)) {
-			props.isValidDate = function isValidDate(currentDate) {
-				if (props.boundaryStart || props.boundaryEnd) {
-					return currentDate.isSameOrAfter(props.boundaryStart, 'day') 
-						&& currentDate.isSameOrBefore(props.boundaryEnd, 'day');
-				} else if (props.boundaryStart) {
-					return currentDate.isSameOrAfter(props.boundaryStart, 'day');
-				} else {
-					return currentDate.isSameOrBefore(props.boundaryEnd, 'day');
-				}
-			};
-		}
-
 		return props;
 	},
 

--- a/DateTime.js
+++ b/DateTime.js
@@ -82,8 +82,8 @@ var Datetime = React.createClass({
 		var formats = this.getFormats( props ),
 			date = props.value || props.defaultValue,
 			selectedDate, viewDate, updateOn, inputValue,
-			boundaryStart = moment.isDate(props.boundaryStart) && moment(props.boundaryStart),
-			boundaryEnd = moment.isDate(props.boundaryEnd) && moment(props.boundaryEnd)
+			boundaryStart = moment(props.boundaryStart).isValid && moment(props.boundaryStart),
+			boundaryEnd = moment(props.boundaryEnd).isValid && moment(props.boundaryEnd)
 		;
 
 		if ( date && typeof date === 'string' )
@@ -417,6 +417,19 @@ var Datetime = React.createClass({
 		this.componentProps.fromThis.forEach( function( name ) {
 			props[ name ] = me[ name ];
 		});
+
+		if (!props.isValidDate && (props.boundaryStart || props.boundaryEnd)) {
+			props.isValidDate = function isValidDate(currentDate, selectedDate) {
+				if (props.boundaryStart || props.boundaryEnd) {
+					return currentDate.isSameOrAfter(props.boundaryStart, 'day') 
+						&& currentDate.isSameOrBefore(props.boundaryEnd, 'day');
+				} else if (boundaryStart) {
+					return currentDate.isSameOrAfter(props.boundaryStart, 'day');
+				} else {
+					return currentDate.isSameOrBefore(props.boundaryEnd, 'day');
+				}
+			}
+		}
 
 		return props;
 	},

--- a/DateTime.js
+++ b/DateTime.js
@@ -39,6 +39,9 @@ var Datetime = React.createClass({
 		strictParsing: TYPES.bool,
 		closeOnSelect: TYPES.bool,
 		closeOnTab: TYPES.bool
+
+		// boundaryStart: TYPES.object | TYPES.string,
+		// boundaryEnd: TYPES.object | TYPES.string,
 	},
 
 	getDefaultProps: function() {
@@ -57,7 +60,10 @@ var Datetime = React.createClass({
 			strictParsing: true,
 			closeOnSelect: false,
 			closeOnTab: true,
-			utc: false
+			utc: false,
+
+			boundaryStart: '',
+			boundaryEnd: ''
 		};
 	},
 
@@ -75,7 +81,9 @@ var Datetime = React.createClass({
 	getStateFromProps: function( props ) {
 		var formats = this.getFormats( props ),
 			date = props.value || props.defaultValue,
-			selectedDate, viewDate, updateOn, inputValue
+			selectedDate, viewDate, updateOn, inputValue,
+			boundaryStart = moment.isDate(props.boundaryStart) && moment(props.boundaryStart),
+			boundaryEnd = moment.isDate(props.boundaryEnd) && moment(props.boundaryEnd)
 		;
 
 		if ( date && typeof date === 'string' )
@@ -106,7 +114,10 @@ var Datetime = React.createClass({
 			viewDate: viewDate,
 			selectedDate: selectedDate,
 			inputValue: inputValue,
-			open: props.open
+			open: props.open,
+
+			boundaryStart: boundaryStart,
+			boundaryEnd: boundaryEnd
 		};
 	},
 
@@ -387,7 +398,7 @@ var Datetime = React.createClass({
 
 	componentProps: {
 		fromProps: ['value', 'isValidDate', 'renderDay', 'renderMonth', 'renderYear', 'timeConstraints'],
-		fromState: ['viewDate', 'selectedDate', 'updateOn'],
+		fromState: ['viewDate', 'selectedDate', 'updateOn', 'boundaryStart', 'boundaryEnd'],
 		fromThis: ['setDate', 'setTime', 'showView', 'addTime', 'subtractTime', 'updateSelectedDate', 'localMoment']
 	},
 

--- a/example/example.js
+++ b/example/example.js
@@ -4,11 +4,13 @@ var ReactDOM = require('react-dom');
 
 ReactDOM.render(
   React.createElement(DateTime, {
-    viewMode: 'months',
-    dateFormat: 'MMMM',
-    isValidDate: function(current) {
-      return current.isBefore(DateTime.moment().startOf('month'));
-    }
+    viewMode: 'days',
+    dateFormat: 'YYYY-MM-DD',
+    timeFormat: 'HH:mm:ss',
+    defaultValue: new Date(),
+    boundaryStart: new Date('2017-02-12T11:21:34+02:00'),
+    boundaryEnd: new Date('2017-02-20T11:50:51+02:00')
   }),
   document.getElementById('datetime')
 );
+

--- a/example/example.js
+++ b/example/example.js
@@ -8,8 +8,8 @@ ReactDOM.render(
     dateFormat: 'YYYY-MM-DD',
     timeFormat: 'HH:mm:ss',
     defaultValue: new Date(),
-    boundaryStart: new Date('2017-02-12T11:21:34+02:00'),
-    boundaryEnd: new Date('2017-02-20T11:50:51+02:00')
+    boundaryStart: '2017-02-12T11:21:34',
+    boundaryEnd: '2017-02-20T11:50:51'
   }),
   document.getElementById('datetime')
 );

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var React = require('react'),
-	assign = require('object-assign'),
-	moment = require('moment')
+	assign = require('object-assign')
 ;
 
 var DOM = React.DOM;
@@ -167,19 +166,19 @@ var DateTimePickerTime = React.createClass({
 			update[ type ] = me[ action ]( type );
 			me.updateState( update );
 
-			// me.timer = setTimeout( function() {
-			// 	me.increaseTimer = setInterval( function() {
-			// 		update[ type ] = me[ action ]( type );
-			// 		me.updateState( update );
-			// 	}, 70);
-			// }, 500);
+			me.timer = setTimeout( function() {
+				me.increaseTimer = setInterval( function() {
+					update[ type ] = me[ action ]( type );
+					me.updateState( update );
+				}, 70);
+			}, 500);
 
-			// me.mouseUpListener = function() {
-			// 	clearTimeout( me.timer );
-			// 	clearInterval( me.increaseTimer );
-			// 	me.props.setTime( type, me.state[ type ] );
-			// 	document.body.removeEventListener( 'mouseup', me.mouseUpListener );
-			// };
+			me.mouseUpListener = function() {
+				clearTimeout( me.timer );
+				clearInterval( me.increaseTimer );
+				me.props.setTime( type, me.state[ type ] );
+				document.body.removeEventListener( 'mouseup', me.mouseUpListener );
+			};
 
 			document.body.addEventListener( 'mouseup', me.mouseUpListener );
 		};
@@ -221,109 +220,135 @@ var DateTimePickerTime = React.createClass({
 	},
 
 	updateState: function( update ) {
+		var hours = parseInt(
+				update.hasOwnProperty('hours')
+					? update.hours
+					: this.state.hours
+		);
+		var minutes = update.hasOwnProperty('minutes')
+				? parseInt(update.minutes)
+				: this.state.minutes;
+		var seconds = update.hasOwnProperty('seconds')
+				? parseInt(update.seconds)
+				: this.state.seconds;
+		var milliseconds = update.hasOwnProperty('milliseconds')
+				? parseInt(update.milliseconds)
+				: this.state.milliseconds;
 		var isConstrained = false;
-		var timeProps = [ 'hours', 'minutes', 'seconds', 'milliseconds' ];
 
-		if (this.props.selectedDate.isAfter(this.props.boundaryStart, 'days')
-			&& this.props.selectedDate.isBefore(this.props.boundaryEnd, 'days')
-		) {
-			console.log( 'time is NOT restricted' );
-
+		if (!this.props.boundaryStart && !this.props.boundaryEnd) {
 			return this.setState( update );
-		} else if (this.props.selectedDate.isSame(this.props.boundaryStart, 'days')) {
+		} else if (this.props.boundaryStart
+			&& this.props.selectedDate.isSame(this.props.boundaryStart, 'days')
+		) {
 			// compare to boundaryStart
 			// hours
-			if (update.hours < this.props.boundaryStart.hours()) {
-				if (this.timeConstraints.hours.max == this.state.hours) {
+			if (hours < this.props.boundaryStart.hours()) {
+				if (hours == this.timeConstraints.hours.min) {
 					update.hours = this.props.boundaryStart.hours();
 					isConstrained = true;
 				} else {
 					update.hours = this.timeConstraints.hours.max;
-				}
-			} else {
-				isConstrained = this.state.hours == this.props.boundaryStart.hours();
-			}
-			
-			// minutes
-			// if (isConstrained && update.minutes < this.props.boundaryStart.minutes()) {
-			// 	if (update.minutes > this.state.minutes) {
-			if (isConstrained) {
-				var minutes = update.hasOwnProperty('minutes')
-					? parseInt(update.minutes)
-					: this.state.minutes;
-				if (minutes == 0) {
-					update.minutes = this.props.boundaryStart.minutes();
-					isConstrained = true;
-				} else if (update.minutes < this.props.boundaryStart.minutes()) {
-					update.minutes = this.timeConstraints.minutes.max;
 					isConstrained = false;
 				}
 			} else {
-				isConstrained = this.state.minutes == this.props.boundaryStart.minutes();
+				isConstrained = hours == this.props.boundaryStart.hours();
+			}
+			
+			// minutes
+			if (isConstrained) {
+				if (minutes == this.timeConstraints.minutes.min) {
+					update.minutes = this.props.boundaryStart.minutes();
+					isConstrained = true;
+				} else if (minutes < this.props.boundaryStart.minutes()) {
+					update.minutes = this.timeConstraints.minutes.max;
+					isConstrained = false;
+				} else {
+					isConstrained = isConstrained && minutes == this.props.boundaryStart.minutes();
+				}
+			} else {
+				isConstrained = isConstrained && minutes == this.props.boundaryStart.minutes();
 			}
 
 			// seconds
 			if (isConstrained) {
-				var seconds = update.hasOwnProperty('seconds')
-					? parseInt(update.seconds)
-					: this.state.seconds;
-				if (seconds == 0) {
+				if (seconds == this.timeConstraints.seconds.min) {
 					update.seconds = this.props.boundaryStart.seconds();
 					isConstrained = true;
-				} else if (update.seconds < this.props.boundaryStart.seconds()) {
+				} else if (seconds < this.props.boundaryStart.seconds()) {
 					update.seconds = this.timeConstraints.minutes.max;
 					isConstrained = false;
+				} else {
+					isConstrained = isConstrained && seconds == this.props.boundaryStart.seconds();
 				}
 			} else {
-				isConstrained = this.state.seconds == this.props.boundaryStart.seconds();
+				isConstrained = isConstrained && seconds == this.props.boundaryStart.seconds();
 			}
 
 			// milliseconds
 			if (isConstrained) {
-				var milliseconds = update.hasOwnProperty('milliseconds')
-					? parseInt(update.milliseconds)
-					: this.state.milliseconds;
-				if (milliseconds == 0) {
+				if (milliseconds == this.timeConstraints.milliseconds.min) {
 					update.milliseconds = this.props.boundaryStart.millisecond();
-				} else if (update.milliseconds < this.props.boundaryStart.millisecond()) {
+				} else if (milliseconds < this.props.boundaryStart.millisecond()) {
 					update.milliseconds = this.timeConstraints.minutes.max;
 				}
 			}
-
-			// if (parseInt(update.minutes, 10) < this.props.boundaryStart.minutes()) {
-			// 	if (this.timeConstraints.minutes.max == this.props.boundaryStart.minutes()) {
-
-			// 	} else {
-
-			// 	}
-			// 	update.minutes = this.timeConstraints.minutes.max;
-			// } else if (parseInt(update.seconds, 10) < this.props.boundaryStart.seconds()) {
-			// 	update.seconds = this.timeConstraints.seconds.max;
-			// } else if (parseInt(update.milliseconds, 10) < this.props.boundaryStart.millisecond()) {
-			// 	update.milliseconds = this.timeConstraints.semillisecondsconds.max;
-			// }
-		} else {
+		} else if (this.props.boundaryEnd
+			&& this.props.selectedDate.isSame(this.props.boundaryEnd, 'days')
+		) {
 			// compare to boundaryEnd
-			// var selectedTime = this.props.boundaryEnd
-			// 	.clone()
-			// 	.hours(update.hours)
-			// 	.minutes(update.minutes)
-			// 	.seconds(update.seconds)
-			// 	.milliseconds(update.milliseconds);
+			// hours
+			if (hours > this.props.boundaryEnd.hours()) {
+				if (hours == this.timeConstraints.hours.max) {
+					update.hours = this.props.boundaryEnd.hours();
+					isConstrained = true;
+				} else {
+					update.hours = this.timeConstraints.hours.min;
+					isConstrained = false;
+				}
+			} else {
+				isConstrained = hours == this.props.boundaryEnd.hours();
+			}
+			
+			// minutes
+			if (isConstrained) {
+				if (minutes == this.timeConstraints.minutes.max) {
+					update.minutes = this.props.boundaryEnd.minutes();
+					isConstrained = true;
+				} else if (minutes > this.props.boundaryEnd.minutes()) {
+					update.minutes = this.timeConstraints.minutes.min;
+					isConstrained = false;
+				} else {
+					isConstrained = isConstrained && minutes == this.props.boundaryEnd.minutes();
+				}
+			} else {
+				isConstrained = isConstrained && minutes == this.props.boundaryEnd.minutes();
+			}
 
-			// if (parseInt(update.hours, 10) > this.props.boundaryEnd.hours()) {
-			// 	update.hours = this.timeConstraints.hours.min;
-			// } else if (parseInt(update.minutes, 10) > this.props.boundaryEnd.minutes()) {
-			// 	update.minutes = this.timeConstraints.minutes.min;
-			// } else if (parseInt(update.seconds, 10) > this.props.boundaryEnd.seconds()) {
-			// 	update.seconds = this.timeConstraints.seconds.min;
-			// } else if (parseInt(update.milliseconds, 10) > this.props.boundaryEnd.millisecond()) {
-			// 	update.milliseconds = this.timeConstraints.semillisecondsconds.min;
-			// }
+			// seconds
+			if (isConstrained) {
+				if (seconds == this.timeConstraints.seconds.max) {
+					update.seconds = this.props.boundaryEnd.seconds();
+					isConstrained = true;
+				} else if (seconds > this.props.boundaryEnd.seconds()) {
+					update.seconds = this.timeConstraints.minutes.min;
+					isConstrained = false;
+				} else {
+					isConstrained = isConstrained && seconds == this.props.boundaryEnd.seconds();
+				}
+			} else {
+				isConstrained = isConstrained && seconds == this.props.boundaryEnd.seconds();
+			}
+
+			// milliseconds
+			if (isConstrained) {
+				if (milliseconds == this.timeConstraints.milliseconds.max) {
+					update.milliseconds = this.props.boundaryEnd.millisecond();
+				} else if (milliseconds < this.props.boundaryEnd.millisecond()) {
+					update.milliseconds = this.timeConstraints.minutes.min;
+				}
+			}
 		}
-
-		console.log( 'time is restricted' )
-		console.log( update );
 
 		return this.setState( update );
 	}

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -238,7 +238,7 @@ var DateTimePickerTime = React.createClass({
 		);
 		var isConstrained = false;
 
-		if (!this.props.boundaryStart && !this.props.boundaryEnd) {
+		if ((!this.props.selectedDate) || (!this.props.boundaryStart && !this.props.boundaryEnd)) {
 			return this.setState( update );
 		} else if (this.props.boundaryStart
 			&& this.props.selectedDate.isSame(this.props.boundaryStart, 'days')

--- a/src/TimeView.js
+++ b/src/TimeView.js
@@ -221,19 +221,21 @@ var DateTimePickerTime = React.createClass({
 
 	updateState: function( update ) {
 		var hours = parseInt(
-				update.hasOwnProperty('hours')
-					? update.hours
-					: this.state.hours
+			update.hasOwnProperty('hours') ? update.hours : this.state.hours,
+			10
 		);
-		var minutes = update.hasOwnProperty('minutes')
-				? parseInt(update.minutes)
-				: this.state.minutes;
-		var seconds = update.hasOwnProperty('seconds')
-				? parseInt(update.seconds)
-				: this.state.seconds;
-		var milliseconds = update.hasOwnProperty('milliseconds')
-				? parseInt(update.milliseconds)
-				: this.state.milliseconds;
+		var minutes = parseInt(
+			update.hasOwnProperty('minutes') ? update.minutes : this.state.minutes, 
+			10
+		);
+		var seconds = parseInt(
+			update.hasOwnProperty('seconds') ? update.seconds : this.state.seconds,
+			10
+		);
+		var milliseconds = parseInt(
+			update.hasOwnProperty('milliseconds') ? update.milliseconds : this.state.milliseconds,
+			10
+		);
 		var isConstrained = false;
 
 		if (!this.props.boundaryStart && !this.props.boundaryEnd) {
@@ -244,7 +246,7 @@ var DateTimePickerTime = React.createClass({
 			// compare to boundaryStart
 			// hours
 			if (hours < this.props.boundaryStart.hours()) {
-				if (hours == this.timeConstraints.hours.min) {
+				if (hours === this.timeConstraints.hours.min) {
 					update.hours = this.props.boundaryStart.hours();
 					isConstrained = true;
 				} else {
@@ -252,42 +254,42 @@ var DateTimePickerTime = React.createClass({
 					isConstrained = false;
 				}
 			} else {
-				isConstrained = hours == this.props.boundaryStart.hours();
+				isConstrained = hours === this.props.boundaryStart.hours();
 			}
 			
 			// minutes
 			if (isConstrained) {
-				if (minutes == this.timeConstraints.minutes.min) {
+				if (minutes === this.timeConstraints.minutes.min) {
 					update.minutes = this.props.boundaryStart.minutes();
 					isConstrained = true;
 				} else if (minutes < this.props.boundaryStart.minutes()) {
 					update.minutes = this.timeConstraints.minutes.max;
 					isConstrained = false;
 				} else {
-					isConstrained = isConstrained && minutes == this.props.boundaryStart.minutes();
+					isConstrained = isConstrained && minutes === this.props.boundaryStart.minutes();
 				}
 			} else {
-				isConstrained = isConstrained && minutes == this.props.boundaryStart.minutes();
+				isConstrained = isConstrained && minutes === this.props.boundaryStart.minutes();
 			}
 
 			// seconds
 			if (isConstrained) {
-				if (seconds == this.timeConstraints.seconds.min) {
+				if (seconds === this.timeConstraints.seconds.min) {
 					update.seconds = this.props.boundaryStart.seconds();
 					isConstrained = true;
 				} else if (seconds < this.props.boundaryStart.seconds()) {
 					update.seconds = this.timeConstraints.minutes.max;
 					isConstrained = false;
 				} else {
-					isConstrained = isConstrained && seconds == this.props.boundaryStart.seconds();
+					isConstrained = isConstrained && seconds === this.props.boundaryStart.seconds();
 				}
 			} else {
-				isConstrained = isConstrained && seconds == this.props.boundaryStart.seconds();
+				isConstrained = isConstrained && seconds === this.props.boundaryStart.seconds();
 			}
 
 			// milliseconds
 			if (isConstrained) {
-				if (milliseconds == this.timeConstraints.milliseconds.min) {
+				if (milliseconds === this.timeConstraints.milliseconds.min) {
 					update.milliseconds = this.props.boundaryStart.millisecond();
 				} else if (milliseconds < this.props.boundaryStart.millisecond()) {
 					update.milliseconds = this.timeConstraints.minutes.max;
@@ -299,7 +301,7 @@ var DateTimePickerTime = React.createClass({
 			// compare to boundaryEnd
 			// hours
 			if (hours > this.props.boundaryEnd.hours()) {
-				if (hours == this.timeConstraints.hours.max) {
+				if (hours === this.timeConstraints.hours.max) {
 					update.hours = this.props.boundaryEnd.hours();
 					isConstrained = true;
 				} else {
@@ -307,42 +309,42 @@ var DateTimePickerTime = React.createClass({
 					isConstrained = false;
 				}
 			} else {
-				isConstrained = hours == this.props.boundaryEnd.hours();
+				isConstrained = hours === this.props.boundaryEnd.hours();
 			}
 			
 			// minutes
 			if (isConstrained) {
-				if (minutes == this.timeConstraints.minutes.max) {
+				if (minutes === this.timeConstraints.minutes.max) {
 					update.minutes = this.props.boundaryEnd.minutes();
 					isConstrained = true;
 				} else if (minutes > this.props.boundaryEnd.minutes()) {
 					update.minutes = this.timeConstraints.minutes.min;
 					isConstrained = false;
 				} else {
-					isConstrained = isConstrained && minutes == this.props.boundaryEnd.minutes();
+					isConstrained = isConstrained && minutes === this.props.boundaryEnd.minutes();
 				}
 			} else {
-				isConstrained = isConstrained && minutes == this.props.boundaryEnd.minutes();
+				isConstrained = isConstrained && minutes === this.props.boundaryEnd.minutes();
 			}
 
 			// seconds
 			if (isConstrained) {
-				if (seconds == this.timeConstraints.seconds.max) {
+				if (seconds === this.timeConstraints.seconds.max) {
 					update.seconds = this.props.boundaryEnd.seconds();
 					isConstrained = true;
 				} else if (seconds > this.props.boundaryEnd.seconds()) {
 					update.seconds = this.timeConstraints.minutes.min;
 					isConstrained = false;
 				} else {
-					isConstrained = isConstrained && seconds == this.props.boundaryEnd.seconds();
+					isConstrained = isConstrained && seconds === this.props.boundaryEnd.seconds();
 				}
 			} else {
-				isConstrained = isConstrained && seconds == this.props.boundaryEnd.seconds();
+				isConstrained = isConstrained && seconds === this.props.boundaryEnd.seconds();
 			}
 
 			// milliseconds
 			if (isConstrained) {
-				if (milliseconds == this.timeConstraints.milliseconds.max) {
+				if (milliseconds === this.timeConstraints.milliseconds.max) {
 					update.milliseconds = this.props.boundaryEnd.millisecond();
 				} else if (milliseconds < this.props.boundaryEnd.millisecond()) {
 					update.milliseconds = this.timeConstraints.minutes.min;


### PR DESCRIPTION
Problem: using `react-datetime` restrict time selection to a certain specific datetime period with millisecond precision.  

### Description
This PR extends the component's API with two new parameters - `boundaryStart` and `boundaryEnd` which set the start and end datetime period respectively. The purpose of it is to tight time setting to the datetime period.

### Motivation and Context
- The problem and solution is described above
- Request for such kind of feature was raised in #18
- If this solution gets accepted I'll provide necessary tests as well as TypeScript definitions 
- _Extra idea_: I believe with defined `boundaryStart`, `boundaryEnd`, or any of those two, `isValidDate` should be automatically generated with a possibility for user to override it

### Checklist
```
[ ] I have added tests covering my changes
[x] All new and existing tests pass
[x] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```
